### PR TITLE
Match section headings with quoted attributes and other fixes

### DIFF
--- a/Git Config.JSON-tmLanguage
+++ b/Git Config.JSON-tmLanguage
@@ -2,21 +2,21 @@
   "scopeName": "source.gitconfig",
   "fileTypes": [".gitconfig"],
   "patterns": [
-    { "match": "^\\s*([a-zA-Z0-9_]+)\\s*=\\s*(.+)$",
+    { "match": "^\\s*([a-zA-Z0-9_]+)\\s*=\\s*([^;#]+)",
       "captures": {
           "1": { "name": "keyword.name" },
           "2": { "name": "string" }
       }
     },
     {
-      "match": "^\\s*[;#].+",
+      "match": "\\s*[;#].+",
       "name": "comment"
     },
     {
-      "match": "^\\[([^\\]]+)\\]",
+      "match": "^\\[([^]\"]*(\"\\w+\")?)\\]",
       "captures": {
         "1": { "name": "meta.header" },
-        "2": { "name": "entity.name.section"}
+        "3": { "name": "entity.name.section"}
       }
     }
   ],

--- a/Git Config.tmLanguage
+++ b/Git Config.tmLanguage
@@ -25,11 +25,11 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*([a-zA-Z0-9_][a-zA-Z0-9_\-]*)\s*=\s*(.+)$</string>
+			<string>^\s*([a-zA-Z0-9_][a-zA-Z0-9_\-]*)\s*=\s*([^;#]+)</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>^\s*[;#].+</string>
+			<string>\s*[;#].+</string>
 			<key>name</key>
 			<string>comment</string>
 		</dict>
@@ -41,14 +41,14 @@
 					<key>name</key>
 					<string>meta.header</string>
 				</dict>
-				<key>2</key>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.section</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\[(\w+)\]</string>
+			<string>^\[([^]"]*("\w+")?)\]</string>
 		</dict>
 	</array>
 	<key>scopeName</key>


### PR DESCRIPTION
Values should stop at a comment marker
Comments don't have to be at the start of a line

See: https://www.kernel.org/pub/software/scm/git/docs/git-config.html#EXAMPLES
