### PR TITLE
Fix whitespace comment lines

### DIFF
--- a/Git Ignore/Git Ignore.JSON-tmLanguage
+++ b/Git Ignore/Git Ignore.JSON-tmLanguage
@@ -3,7 +3,7 @@
   "fileTypes": [".gitignore"],
   "patterns": [
     {
-      "match": "[#].+$",
+      "match": "[#].*$",
       "name": "comment"
     }
   ],

--- a/Git Ignore/Git Ignore.tmLanguage
+++ b/Git Ignore/Git Ignore.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>[#].+$</string>
+			<string>[#].*$</string>
 			<key>name</key>
 			<string>comment</string>
 		</dict>


### PR DESCRIPTION
Example:

```
# Line 1
#
# Line 3
```

Line two wasn't matched.
