### PR TITLE
Fix comment char detection in .gitignore

### DIFF
--- a/Git Ignore/Git Ignore.tmLanguage
+++ b/Git Ignore/Git Ignore.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>[#].*$</string>
+			<string>^\s*[#].*$</string>
 			<key>name</key>
 			<string>comment</string>
 		</dict>


### PR DESCRIPTION
Anywhere on a line, `#` is being interpreted as a comment character. According to `gitignore(1)`, only lines beginning with a `#` are comments.

Here are some valid patterns that I am currently seeing partially misinterpreted as comments. These are intended to ignore swap/backup meta-files left behind by editors such as Vim or Emacs.

```
\#*#
.#*
```

This PR fixes that, so `#` is only a comment char when it is the first non-whitespace character on a line.
